### PR TITLE
Update fetch.sh

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -12,8 +12,13 @@ arch=amd64
 deb_name=zoom_$arch.deb
 rm -rf DEBIAN $deb_name
 wget -q https://zoom.us/client/$version/$deb_name
+
 dpkg -e $deb_name
-version=$(cat DEBIAN/control | grep ^Version | cut -d\  -f2)
+#
+# Removed unnecessary processing since vesion can be directly obtained using dpkg -f debname Version.
+#
+#version=$(cat DEBIAN/control | grep ^Version | cut -d" " -f2)
+version=$(dpkg -f ${deb_name} Version)
 echo "Latest zoom version is $version"
 target=zoom_${version}_$arch.deb
 if [ -e $target ]; then
@@ -23,4 +28,5 @@ else
     mv $deb_name $target
     ./build-repo.sh
 fi
+
 rm -rf DEBIAN $deb_name


### PR DESCRIPTION
Removed unnecessary processing since vesion can be directly obtained using dpkg -f debname Version.
TODO: check if there's still a need to use the extracted metadata in build_repo.sh